### PR TITLE
Website url fix for pool #2

### DIFF
--- a/list.json
+++ b/list.json
@@ -7,7 +7,7 @@
         "public_key": "gcs12ezltnndc6f6ds4zcwdy82d6mv94xx2anch950"
     },
     {
-        "label": "Ghoststake.io Ghost Pool",
+        "label": "Ghoststake.com Ghost Pool",
         "description": "Coldstaking pool for Ghost",
         "website": "https://ghoststake.com/",
         "fee": "4",


### PR DESCRIPTION
label description website url fix to Ghoststake.com Ghost Pool